### PR TITLE
Replace voice searches stats in accessibility chapter. Fix #3260

### DIFF
--- a/src/content/en/2022/accessibility.md
+++ b/src/content/en/2022/accessibility.md
@@ -22,7 +22,7 @@ featured_stat_label_3: Sites using `:focus-visible`, compared to only 0.6% last 
 
 ## Introduction
 
-Half of all web searches are <a hreflang="en" href="https://review42.com/resources/voice-search-stats/">performed by voice</a>. 85% of Facebook videos are watched <a hreflang="en" href="https://idearocketanimation.com/18761-facebook-video-captions/">with closed captions on and sound off</a>. When you ask voice assistants like Siri, Alexa, and Cortana a question, they typically read their answer from a web page using screen reader technology that has been around <a hreflang="en" href="https://www.theverge.com/23203911/screen-readers-history-blind-henter-curran-teh-nvda">for as long as personal computers have existed</a>.
+27% of the global online population is <a hreflang="en" href="https://www.gwi.com/hubfs/Downloads/Voice-Search-report.pdf">using voice search on mobile</a>. 85% of Facebook videos are watched <a hreflang="en" href="https://idearocketanimation.com/18761-facebook-video-captions/">with closed captions on and sound off</a>. When you ask voice assistants like Siri, Alexa, and Cortana a question, they typically read their answer from a web page using screen reader technology that has been around <a hreflang="en" href="https://www.theverge.com/23203911/screen-readers-history-blind-henter-curran-teh-nvda">for as long as personal computers have existed</a>.
 
 When does a software feature cease being an "accessibility feature" and simply become a "feature" that we all use? Ask yourself that the next time you put your smartphone in silent/vibrate mode – especially if you're not a member of the Deaf/Hard of Hearing community.
 


### PR DESCRIPTION
Addresses #3260. I went for the simplest change of replacing the existing stat with a similar one.

I came across that report thanks to Google’s search marketing (https://www.thinkwithgoogle.com/marketing-strategies/search/voice-search-mobile-use-statistics/). I’ve never come across GWI as a source before but their methodology (page 18 of the PDF) checks out – it’s a questionnaire, they make it clear what caveats there might be in the numbers.